### PR TITLE
BugFix: 记事本不能预览

### DIFF
--- a/app/assets/javascripts/homeland/note/application.coffee
+++ b/app/assets/javascripts/homeland/note/application.coffee
@@ -1,29 +1,28 @@
 window.NoteView = Backbone.View.extend
   el: "body"
   events:
-    "click .editor-toolbar .edit a": "toggleEditView"
-    "click .editor-toolbar .preview a": "togglePreviewView"
+    "click .editor-toolbar a.preview": "togglePreviewView"
 
   initialize: (opts) ->
     $("<div id='preview' class='markdown form-control' style='display:none;'></div>").insertAfter( $('#note_body') )
     window._editor = new Editor()
 
-  toggleEditView: (e) ->
-    $(e.target).parent().addClass('active')
-    $('.preview a').parent().removeClass('active')
-    $('#preview').hide()
-    $('#note_body').show()
-    false
-
   togglePreviewView: (e) ->
-    $(e.target).parent().addClass('active')
-    $('.edit a').parent().removeClass('active')
-    $('#preview').html('Loading...')
-    $('#note_body').hide()
-    $('#preview').show()
-    $.post '/notes/preview', {body: $('#note_body').val()}, (data)->
-      $('#preview').html(data)
-      false
+    btn = $(e.target)
+    preview_box = $('#preview')
+    note_body = $('#note_body')
+    if btn.hasClass('active')
+      preview_box.hide()
+      note_body.show()
+      btn.removeClass('active')
+    else
+      btn.addClass('active')
+      note_body.hide()
+      preview_box.html('Loading...')
+      preview_box.css("height", note_body.height())
+      preview_box.show()
+      $.post '/notes/preview', {body: note_body.val()}, (data)->
+        preview_box.html(data)
     false
 
 document.addEventListener 'turbolinks:load',  ->


### PR DESCRIPTION
修正 https://github.com/ruby-china/homeland-note/commit/d7a69f50836442847bea33cae805bdb828de3f89 引起的记事本 markdown 内容不能正常预览的 bug

fix https://github.com/ruby-china/homeland-note/issues/1

@huacnlee 